### PR TITLE
Fix android crop alignment issue

### DIFF
--- a/example/manipulator/ImageManipulator.js
+++ b/example/manipulator/ImageManipulator.js
@@ -440,7 +440,7 @@ class ExpoImageManipulator extends Component {
                 <View style={{ flex: 1, backgroundColor: 'black', width: Dimensions.get('window').width }}>
                     <ScrollView
                         style={{ position: 'relative', flex: 1 }}
-                        contentContainerStyle={{ backgroundColor: 'black' }}
+                        contentContainerStyle={{ backgroundColor: 'black', flex: 1, justifyContent: 'center' }}
                         maximumZoomScale={5}
                         minimumZoomScale={0.5}
                         onScroll={this.onHandleScroll}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-image-crop",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Crop, rotate and flip images without detach your expo project!",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Forked from master repo. 
The crop overlay had alignment issue with the rendered image. This PR implements the fix for the rendered image to be centre aligned in the view. This helps the crop overlay to calculate the correct region